### PR TITLE
Increased profile image url maxlength

### DIFF
--- a/server/models/user.js
+++ b/server/models/user.js
@@ -16,7 +16,7 @@ var UserSchema = new mongoose.Schema({
   },
   profileImage: {
     type: String,
-    maxlength: 50
+    maxlength: 75
   },
   lastProject: {
     name: {


### PR DESCRIPTION
Ran into an issue with the image url being too long to save to the database:

```ValidationError: User validation failed: profileImage: Path `profile
Image` (`https://avatars0.githubusercontent.com/u/25966390?v=3`) is longer than the maximum allowed length (50).```
